### PR TITLE
An open source solution for pdf import was added

### DIFF
--- a/2D_Editor/2D_Editor.csproj
+++ b/2D_Editor/2D_Editor.csproj
@@ -78,24 +78,6 @@
     <Reference Include="FontAwesome.WPF, Version=4.7.0.37774, Culture=neutral, PublicKeyToken=0758b07a11a4f466, processorArchitecture=MSIL">
       <HintPath>..\packages\FontAwesome.WPF.4.7.0.9\lib\net40\FontAwesome.WPF.dll</HintPath>
     </Reference>
-    <Reference Include="Gnostice.Converter, Version=21.1.870.2167, Culture=neutral, PublicKeyToken=fc8cb3ab6a24df63, processorArchitecture=MSIL">
-      <HintPath>..\packages\Gnostice.DocumentStudio.Converter.21.1.870\lib\net45\Gnostice.Converter.dll</HintPath>
-    </Reference>
-    <Reference Include="Gnostice.Core, Version=21.1.870.2167, Culture=neutral, PublicKeyToken=fc8cb3ab6a24df63, processorArchitecture=MSIL">
-      <HintPath>..\packages\Gnostice.DocumentStudio.Foundation.21.1.870\lib\net45\Gnostice.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Gnostice.Documents, Version=21.1.870.2167, Culture=neutral, PublicKeyToken=fc8cb3ab6a24df63, processorArchitecture=MSIL">
-      <HintPath>..\packages\Gnostice.DocumentStudio.Foundation.21.1.870\lib\net45\Gnostice.Documents.dll</HintPath>
-    </Reference>
-    <Reference Include="Gnostice.Graphics.GDIPlus, Version=21.1.870.2167, Culture=neutral, PublicKeyToken=fc8cb3ab6a24df63, processorArchitecture=MSIL">
-      <HintPath>..\packages\Gnostice.DocumentStudio.Foundation.21.1.870\lib\net45\Gnostice.Graphics.GDIPlus.dll</HintPath>
-    </Reference>
-    <Reference Include="Gnostice.Graphics.Skia, Version=21.1.870.2167, Culture=neutral, PublicKeyToken=fc8cb3ab6a24df63, processorArchitecture=MSIL">
-      <HintPath>..\packages\Gnostice.DocumentStudio.Foundation.21.1.870\lib\net45\Gnostice.Graphics.Skia.dll</HintPath>
-    </Reference>
-    <Reference Include="Gnostice.ImageEngine, Version=21.1.870.2167, Culture=neutral, PublicKeyToken=fc8cb3ab6a24df63, processorArchitecture=MSIL">
-      <HintPath>..\packages\Gnostice.DocumentStudio.Foundation.21.1.870\lib\net45\Gnostice.ImageEngine.dll</HintPath>
-    </Reference>
     <Reference Include="IdentityModel, Version=4.1.0.0, Culture=neutral, PublicKeyToken=e7877f4675df049f, processorArchitecture=MSIL">
       <HintPath>..\packages\IdentityModel.4.1.0\lib\net472\IdentityModel.dll</HintPath>
     </Reference>
@@ -149,12 +131,6 @@
     </Reference>
     <Reference Include="RestSharp, Version=106.11.4.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.11.4\lib\net452\RestSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Spire.License, Version=1.3.8.40, Culture=neutral, PublicKeyToken=b1144360237c8b3f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Spire.PDF.7.3.3\lib\net40\Spire.License.dll</HintPath>
-    </Reference>
-    <Reference Include="Spire.Pdf, Version=7.3.3.0, Culture=neutral, PublicKeyToken=663f351905198cb3, processorArchitecture=MSIL">
-      <HintPath>..\packages\Spire.PDF.7.3.3\lib\net40\Spire.Pdf.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/2D_Editor/2D_Editor.csproj
+++ b/2D_Editor/2D_Editor.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props" Condition="Exists('..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,6 +31,8 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -137,6 +140,9 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PdfiumViewer, Version=2.13.0.0, Culture=neutral, PublicKeyToken=91e4789cfb0609e0, processorArchitecture=MSIL">
+      <HintPath>..\packages\PdfiumViewer.2.13.0.0\lib\net20\PdfiumViewer.dll</HintPath>
     </Reference>
     <Reference Include="Photon-DotNet">
       <HintPath>..\Libs\Photon-DotNet.dll</HintPath>
@@ -356,4 +362,10 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PdfiumViewer.Native.x86_64.v8-xfa.2018.4.8.256\build\PdfiumViewer.Native.x86_64.v8-xfa.props'))" />
+  </Target>
 </Project>

--- a/2D_Editor/PresentationHandling.cs
+++ b/2D_Editor/PresentationHandling.cs
@@ -4,7 +4,6 @@
 using ImmersivePresentation;
 using Microsoft.Win32;
 using Newtonsoft.Json;
-using Spire.Pdf;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -20,7 +19,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using PdfiumViewer;
-//using Gnostice.PDFOne;
 
 namespace _2D_Editor
 {
@@ -1127,37 +1125,6 @@ namespace _2D_Editor
                 }
 
                 string pdfPath = openFileDialog.FileName;
-
-                //Spire Pdf
-                if (false)
-                {
-
-                Spire.Pdf.PdfDocument pdf = new Spire.Pdf.PdfDocument();
-                pdf.LoadFromFile(pdfPath);
-
-                BitmapSource source;
-                Bitmap bmp;
-
-                for(int i = 0; i < pdf.Pages.Count; i++)
-                {
-                    string tempFileStorage = templocalImageStorage + "background-" + i + ".png";
-                    Directory.CreateDirectory(templocalImageStorage);
-                    bmp = (Bitmap)pdf.SaveAsImage(i);
-                    bmp.Save(tempFileStorage, ImageFormat.Png);
-                    Console.WriteLine(tempFileStorage);
-                    //Add image to stage i
-                    if (i < openPresentation.stages.Count)
-                    {
-                        addNewBackgroundImage(tempFileStorage, i);
-                        //addNewImage(tempFileStorage);
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-
-                }
 
                 //PdfiumViewer
                 //The pdfium.dll must be in the Debug folder

--- a/2D_Editor/PresentationHandling.cs
+++ b/2D_Editor/PresentationHandling.cs
@@ -19,6 +19,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using PdfiumViewer;
 //using Gnostice.PDFOne;
 
 namespace _2D_Editor
@@ -1127,7 +1128,11 @@ namespace _2D_Editor
 
                 string pdfPath = openFileDialog.FileName;
 
-                PdfDocument pdf = new PdfDocument();
+                //Spire Pdf
+                if (false)
+                {
+
+                Spire.Pdf.PdfDocument pdf = new Spire.Pdf.PdfDocument();
                 pdf.LoadFromFile(pdfPath);
 
                 BitmapSource source;
@@ -1151,6 +1156,38 @@ namespace _2D_Editor
                         break;
                     }
                 }
+
+                }
+
+                //PdfiumViewer
+                //The pdfium.dll must be in the Debug folder
+                //The version that should be used is the x86 noV8 noxfa version
+                //The dll is available at https://github.com/pvginkel/PdfiumBuild/blob/master/Builds/2018-04-08/PdfiumViewer-x86-no_v8-no_xfa/pdfium.dll
+
+                PdfiumViewer.PdfDocument myPdfiumPdf = PdfiumViewer.PdfDocument.Load(pdfPath);
+
+                BitmapSource sourcefium;
+                Bitmap bmpfium;
+
+                for (int i = 0; i < myPdfiumPdf.PageCount; i++)
+                {
+                    string tempFileStorage = templocalImageStorage + "background-" + i + ".png";
+                    Directory.CreateDirectory(templocalImageStorage);
+                    bmpfium = (Bitmap)myPdfiumPdf.Render(i, 300, 300, false);
+                    bmpfium.Save(tempFileStorage, ImageFormat.Png);
+                    Console.WriteLine(tempFileStorage);
+                    //Add image to stage i
+                    if (i < openPresentation.stages.Count)
+                    {
+                        addNewBackgroundImage(tempFileStorage, i);
+                        //addNewImage(tempFileStorage);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
             }
         }
 

--- a/2D_Editor/Properties/licenses.licx
+++ b/2D_Editor/Properties/licenses.licx
@@ -1,1 +1,1 @@
-Gnostice.Licensing.License, Gnostice.Documents
+

--- a/2D_Editor/packages.config
+++ b/2D_Editor/packages.config
@@ -20,6 +20,8 @@
   <package id="Microsoft.IdentityModel.Logging" version="5.6.0" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.6.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
+  <package id="PdfiumViewer" version="2.13.0.0" targetFramework="net472" />
+  <package id="PdfiumViewer.Native.x86_64.v8-xfa" version="2018.4.8.256" targetFramework="net472" />
   <package id="RestSharp" version="106.11.4" targetFramework="net472" />
   <package id="Spire.PDF" version="7.3.3" targetFramework="net472" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net472" />


### PR DESCRIPTION
PDFiumViewer is an open-source project under the Apache 2.0 License. It allows converting pdf files to an image format ( in this case png). In order to make it work, we needed to add a build of the open-source pdfium. This build is added in the form of the file pdfium.dll.